### PR TITLE
Fix option in .bundle/config 

### DIFF
--- a/scale.app/.bundle/config
+++ b/scale.app/.bundle/config
@@ -1,4 +1,3 @@
 ---
 BUNDLE_PATH: "vendor/bundle/"
 BUNDLE_DISABLE_SHARED_GEMS: "true"
-BUNDLE_NO_INSTALL: "true"


### PR DESCRIPTION

Hello! :smile:
I am a student studying computer science in Korea.
  
  
While using this project, there was one problem with setting up the environment though it has been now resolved. I would like to share it with you guys.


I used docker to set up **ubuntu 16.04 offline** in my local.

However, when I was setting up the environment following the guideline,
the following **error happened at this command**:  `bundle exec rake db:migrate`

```
root@5b6efe462c06:~/SCALe/scale.app# bundle exec rake db:migrate
Could not find rake-12.3.3 in any of the sources
Run `bundle install` to install missing gems.
```

To solve this error, I tried out various things. :persevere:

What I realized later was that **ruby bundle wasn't installed properly** when I typed in command
`bundle install --path vendor/bundle/`

How I fixed it was to delete an option at the very last line in .bundle/config file.
line 3: `BUNDLE_NO_INSTALL: "true"`

After that, if you reinstall bundle and migrate, it works as expected.
```
root@5b6efe462c06:~/SCALe/scale.app# bundle exec rake db:migrate
==  CreateDisplays: migrating =================================================
-- create_table(:displays)
   -> 0.0071s
==  CreateDisplays: migrated (0.0072s) ========================================

==  AddProjectIdToDisplays: migrating =========================================
-- add_column(:displays, :project_id, :integer, {:default=>0})
   -> 0.0025s
==  AddProjectIdToDisplays: migrated (0.0027s) ================================

==  CreateProjects: migrating =================================================
-- create_table(:projects)
   -> 0.0016s
==  CreateProjects: migrated (0.0017s) ========================================

==  AddScaleIdToDisplays: migrating ===========================================
-- add_column(:displays, :meta_alert_id, :integer, {:default=>0})
   -> 0.0012s
==  AddScaleIdToDisplays: migrated (0.0015s) ==================================

==  CreateMessages: migrating =================================================
-- create_table(:messages)
   -> 0.0010s
==  CreateMessages: migrated (0.0015s) ========================================

==  AddDiagnosticId: migrating ================================================
-- add_column(:displays, :diagnostic_id, :integer, {:default=>0})
   -> 0.0009s
==  AddDiagnosticId: migrated (0.0010s) =======================================

root@5b6efe462c06:~/SCALe/scale.app#
```


I hope this issue will be fixed soon for those who are having the same problem.
These are stars for you :star2: :star2: :star2:

Thanks! 
